### PR TITLE
Allow PR writes for release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
The release job is having some issues when triggering releases as it is not able to create pull requests.
This PR is fixing this.