### PR TITLE
Improve the release process

### DIFF
--- a/.changeset/late-snakes-bake.md
+++ b/.changeset/late-snakes-bake.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/yasgui": patch
+---
+
+Improve the release process

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,3 +64,5 @@ jobs:
 
           # Clean up the archive files
           rm build.zip build.tar.gz *.tgz
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,16 +50,14 @@ jobs:
           zip -r build.zip build
           tar -czvf build.tar.gz build
 
-          # Upload the archive to all published packages + the package archive itself
+          # Upload the archive to all published packages
           echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[]|[.name, .version] | @tsv' |
           while IFS=$'\t' read -r name version; do
-            archive_name=$(npm pack --workspace "$name" --json | jq -r '.[0].filename')
             tag="$name@$version"
 
             # Upload the archives to the release
             gh release upload $tag build.zip --clobber
             gh release upload $tag build.tar.gz --clobber
-            gh release upload $tag $archive_name --clobber
           done
 
           # Clean up the archive files


### PR DESCRIPTION
This adds the missing `GH_TOKEN` environment variable and remove the build of each package, as they are already included in the `build` directory.