### PR TITLE
Fix the cleanup part of the release step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,6 @@ jobs:
           done
 
           # Clean up the archive files
-          rm build.zip build.tar.gz *.tgz
+          rm build.zip build.tar.gz
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fix the cleanup part of the release step, by not trying to remove `*.tgz`.