### PR TITLE
Add a `queryBefore` event on Yasgui and Yasqe

### DIFF
--- a/packages/yasgui/src/Tab.ts
+++ b/packages/yasgui/src/Tab.ts
@@ -33,6 +33,8 @@ export interface Tab {
   emit(event: "change", tab: Tab, config: PersistedJson): boolean;
   on(event: "query", listener: (tab: Tab) => void): this;
   emit(event: "query", tab: Tab): boolean;
+  on(event: "queryBefore", listener: (tab: Tab) => void): this;
+  emit(event: "queryBefore", tab: Tab): boolean;
   on(event: "queryAbort", listener: (tab: Tab) => void): this;
   emit(event: "queryAbort", tab: Tab): boolean;
   on(event: "queryResponse", listener: (tab: Tab) => void): this;
@@ -353,6 +355,7 @@ export class Tab extends EventEmitter {
 
     this.yasqe.on("blur", this.handleYasqeBlur);
     this.yasqe.on("query", this.handleYasqeQuery);
+    this.yasqe.on("queryBefore", this.handleYasqeQueryBefore);
     this.yasqe.on("queryAbort", this.handleYasqeQueryAbort);
     this.yasqe.on("resize", this.handleYasqeResize);
 
@@ -369,6 +372,7 @@ export class Tab extends EventEmitter {
     this.yasqe?.off("resize", this.handleYasqeResize);
     this.yasqe?.off("autocompletionShown", this.handleAutocompletionShown);
     this.yasqe?.off("autocompletionClose", this.handleAutocompletionClose);
+    this.yasqe?.off("queryBefore", this.handleYasqeQueryBefore);
     this.yasqe?.off("queryResponse", this.handleQueryResponse);
     this.yasqe?.destroy();
     this.yasqe = undefined;
@@ -387,6 +391,9 @@ export class Tab extends EventEmitter {
   };
   handleYasqeQueryAbort = () => {
     this.emit("queryAbort", this);
+  };
+  handleYasqeQueryBefore = () => {
+    this.emit("queryBefore", this);
   };
   handleYasqeResize = (_yasqe: Yasqe, newSize: string) => {
     this.persistentJson.yasqe.editorHeight = newSize;

--- a/packages/yasgui/src/index.ts
+++ b/packages/yasgui/src/index.ts
@@ -60,6 +60,8 @@ export interface Yasgui {
   emit(event: "tabClose", instance: Yasgui, tab: Tab): boolean;
   on(event: "query", listener: (instance: Yasgui, tab: Tab) => void): this;
   emit(event: "query", instance: Yasgui, tab: Tab): boolean;
+  on(event: "queryBefore", listener: (instance: Yasgui, tab: Tab) => void): this;
+  emit(event: "queryBefore", instance: Yasgui, tab: Tab): boolean;
   on(event: "queryAbort", listener: (instance: Yasgui, tab: Tab) => void): this;
   emit(event: "queryAbort", instance: Yasgui, tab: Tab): boolean;
   on(event: "queryResponse", listener: (instance: Yasgui, tab: Tab) => void): this;
@@ -274,6 +276,7 @@ export class Yasgui extends EventEmitter {
   private _registerTabListeners(tab: Tab) {
     tab.on("change", (tab) => this.emit("tabChange", this, tab));
     tab.on("query", (tab) => this.emit("query", this, tab));
+    tab.on("queryBefore", (tab) => this.emit("queryBefore", this, tab));
     tab.on("queryAbort", (tab) => this.emit("queryAbort", this, tab));
     tab.on("queryResponse", (tab) => this.emit("queryResponse", this, tab));
     tab.on("autocompletionShown", (tab, widget) => this.emit("autocompletionShown", this, tab, widget));

--- a/packages/yasqe/src/index.ts
+++ b/packages/yasqe/src/index.ts
@@ -16,6 +16,7 @@ import { merge, escape } from "lodash-es";
 
 import getDefaults from "./defaults";
 import CodeMirror from "./CodeMirror";
+import { YasqeAjaxConfig } from "./sparql";
 
 export interface Yasqe {
   on(eventName: "query", handler: (instance: Yasqe, req: superagent.SuperAgentRequest) => void): void;
@@ -35,6 +36,8 @@ export interface Yasqe {
   off(eventName: "error", handler: (instance: Yasqe) => void): void;
   on(eventName: "blur", handler: (instance: Yasqe) => void): void;
   off(eventName: "blur", handler: (instance: Yasqe) => void): void;
+  on(eventName: "queryBefore", handler: (instance: Yasqe, config: YasqeAjaxConfig) => void): void;
+  off(eventName: "queryBefore", handler: (instance: Yasqe, config: YasqeAjaxConfig) => void): void;
   on(eventName: "queryResults", handler: (instance: Yasqe, results: any, duration: number) => void): void;
   off(eventName: "queryResults", handler: (instance: Yasqe, results: any, duration: number) => void): void;
   on(eventName: "autocompletionShown", handler: (instance: Yasqe, widget: any) => void): void;

--- a/packages/yasqe/src/sparql.ts
+++ b/packages/yasqe/src/sparql.ts
@@ -52,6 +52,7 @@ export function getAjaxConfig(
 export async function executeQuery(yasqe: Yasqe, config?: YasqeAjaxConfig): Promise<any> {
   var req: superagent.SuperAgentRequest;
   try {
+    yasqe.emit("queryBefore", yasqe, config);
     getAjaxConfig(yasqe, config);
     const populatedConfig = getAjaxConfig(yasqe, config);
     if (!populatedConfig) {


### PR DESCRIPTION
Like the `query` event, but emitted before the request is sent to the SPARQL endpoint. 

This enables the developers to have a way to add some checks before the query is sent to the endpoint, e.g. add a LIMIT if not present

I also noticed that `getAjaxConfig(yasqe, config);` is called twice: https://github.com/zazuko/Yasgui/blob/main/packages/yasqe/src/sparql.ts#L55

```js
getAjaxConfig(yasqe, config);
const populatedConfig = getAjaxConfig(yasqe, config);
```

Is there a reason for that or is it a typo? It seems like only the second one is useful