### PR TITLE
Fix `@zazuko/yasgui-utils` build

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,7 +2,7 @@
   "name": "@zazuko/yasgui-utils",
   "version": "4.3.2",
   "description": "Utils for YASGUI libs",
-  "main": "build/index.min.js",
+  "main": "build/utils.min.js",
   "types": "build/ts/src/index.d.ts",
   "license": "MIT",
   "author": "Triply <info@triply.cc>",

--- a/webpack/config.ts
+++ b/webpack/config.ts
@@ -264,6 +264,7 @@ const config: webpack.Configuration = {
     Yasgui: [path.resolve(__dirname, "./../packages/yasgui/src/index.ts")],
     Yasqe: path.resolve(__dirname, "./../packages/yasqe/src/index.ts"),
     Yasr: path.resolve(__dirname, "./../packages/yasr/src/index.ts"),
+    Utils: path.resolve(__dirname, "./../packages/utils/src/index.ts"),
   },
 };
 


### PR DESCRIPTION
I am using `vite` for my web projects, and it fails to import from `@zazuko/yasgui-utils` because the file defined as `main` in the yasgui-utils `package.json` does not exist: https://github.com/zazuko/Yasgui/blob/main/packages/utils/package.json#L5

Checking the published code for the `@zazuko/yasgui-utils` NPM package show only 1 `ts` folder with the source code not compiled to JS or anything: https://www.npmjs.com/package/@zazuko/yasgui-utils?activeTab=code

Which means there is something broken in the webpack build process for the `@zazuko/yasgui-utils` package

I fixed the `webpack/config.ts` file to properly generate a `build/utils.min.js` for `packages/utils`, I also fixed the `main` entry in the utils `package.json` file to point to the right file

I went for the simplest fix since I am not a webpack expert, so feel free to make changes if you want a different filename or else

@ludovicm67 