### PR TITLE
Remove dependency on `superagent`, replace by the standard `fetch` API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3204,13 +3204,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cookiejar": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
-      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/dompurify": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.4.0.tgz",
@@ -3503,17 +3496,6 @@
       "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/superagent": {
-      "version": "4.1.24",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.24.tgz",
-      "integrity": "sha512-mEafCgyKiMFin24SDzWN7yAADt4gt6YawFiNMp0QS5ZPboORfyxFt0s3VzJKhTaKg9py/4FUmrHLTNfJKt9Rbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/cookiejar": "*",
         "@types/node": "*"
       }
     },
@@ -4440,12 +4422,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -5617,15 +5593,6 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "license": "MIT"
     },
-    "node_modules/component-emitter": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
-      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -5752,12 +5719,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
-    },
-    "node_modules/cookiejar": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
-      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "license": "MIT"
     },
     "node_modules/copy-webpack-plugin": {
@@ -6420,16 +6381,6 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/dezalgo": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
-      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -7517,12 +7468,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "license": "MIT"
-    },
     "node_modules/fast-uri": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
@@ -7724,21 +7669,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
-      "license": "MIT",
-      "dependencies": {
-        "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -8286,15 +8216,6 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/hexoid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/hosted-git-info": {
@@ -14436,52 +14357,6 @@
         "postcss": "^8.4.31"
       }
     },
-    "node_modules/superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
-      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.4",
-        "debug": "^4.3.4",
-        "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
-        "methods": "^1.1.2",
-        "mime": "2.6.0",
-        "qs": "^6.11.0",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">=6.4.0 <13 || >=14"
-      }
-    },
-    "node_modules/superagent/node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/superagent/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -16398,7 +16273,7 @@
     },
     "packages/utils": {
       "name": "@zazuko/yasgui-utils",
-      "version": "4.3.2",
+      "version": "4.3.3",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.5.4",
@@ -16417,14 +16292,14 @@
     },
     "packages/yasgui": {
       "name": "@zazuko/yasgui",
-      "version": "4.3.2",
+      "version": "4.3.3",
       "license": "MIT",
       "dependencies": {
         "@tarekraafat/autocomplete.js": "^7.2.0",
         "@types/lodash-es": "^4.17.3",
-        "@zazuko/yasgui-utils": "^4.3.2",
-        "@zazuko/yasqe": "^4.3.2",
-        "@zazuko/yasr": "^4.3.2",
+        "@zazuko/yasgui-utils": "^4.3.3",
+        "@zazuko/yasqe": "^4.3.3",
+        "@zazuko/yasr": "^4.3.3",
         "autosuggest-highlight": "^3.1.1",
         "blueimp-md5": "^2.12.0",
         "choices.js": "^9.0.1",
@@ -16432,15 +16307,13 @@
         "es6-object-assign": "^1.1.0",
         "jsuri": "^1.3.1",
         "lodash-es": "^4.17.15",
-        "sortablejs": "^1.10.2",
-        "superagent": "^8.1.2"
+        "sortablejs": "^1.10.2"
       },
       "devDependencies": {
         "@types/autosuggest-highlight": "^3.1.0",
         "@types/blueimp-md5": "^2.7.0",
         "@types/jsuri": "^1.3.30",
-        "@types/node": "^22.5.4",
-        "@types/superagent": "^4.1.24"
+        "@types/node": "^22.5.4"
       }
     },
     "packages/yasgui/node_modules/@types/node": {
@@ -16455,20 +16328,18 @@
     },
     "packages/yasqe": {
       "name": "@zazuko/yasqe",
-      "version": "4.3.2",
+      "version": "4.3.3",
       "license": "MIT",
       "dependencies": {
         "@types/lodash-es": "^4.17.3",
-        "@zazuko/yasgui-utils": "^4.3.2",
+        "@zazuko/yasgui-utils": "^4.3.3",
         "codemirror": "^5.51.0",
         "lodash-es": "^4.17.15",
-        "query-string": "^6.10.1",
-        "superagent": "^8.1.2"
+        "query-string": "^6.10.1"
       },
       "devDependencies": {
         "@types/codemirror": "0.0.100",
-        "@types/node": "^22.5.4",
-        "@types/superagent": "^4.1.24"
+        "@types/node": "^22.5.4"
       },
       "engines": {
         "node": ">= 8"
@@ -16486,14 +16357,14 @@
     },
     "packages/yasr": {
       "name": "@zazuko/yasr",
-      "version": "4.3.2",
+      "version": "4.3.3",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
         "@json2csv/plainjs": "^7.0.4",
         "@types/lodash-es": "^4.17.3",
-        "@zazuko/yasgui-utils": "^4.3.2",
-        "@zazuko/yasqe": "^4.3.2",
+        "@zazuko/yasgui-utils": "^4.3.3",
+        "@zazuko/yasqe": "^4.3.3",
         "codemirror": "^5.51.0",
         "colors": "^1.4.0",
         "column-resizer": "^1.4.0",
@@ -16513,7 +16384,6 @@
         "@types/node": "^22.5.4",
         "@types/papaparse": "^5.3.2",
         "@types/sanitize-html": "^1.20.2",
-        "@types/superagent": "^4.1.4",
         "better-npm-run": "^0.1.1",
         "ts-essentials": "^7.0.1"
       },

--- a/packages/yasgui/package.json
+++ b/packages/yasgui/package.json
@@ -33,15 +33,13 @@
     "es6-object-assign": "^1.1.0",
     "jsuri": "^1.3.1",
     "lodash-es": "^4.17.15",
-    "sortablejs": "^1.10.2",
-    "superagent": "^8.1.2"
+    "sortablejs": "^1.10.2"
   },
   "devDependencies": {
     "@types/autosuggest-highlight": "^3.1.0",
     "@types/blueimp-md5": "^2.7.0",
     "@types/jsuri": "^1.3.30",
-    "@types/node": "^22.5.4",
-    "@types/superagent": "^4.1.24"
+    "@types/node": "^22.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/yasgui/src/Tab.ts
+++ b/packages/yasgui/src/Tab.ts
@@ -194,16 +194,14 @@ export class Tab extends EventEmitter {
 
   private checkEndpointForCors(endpoint: string) {
     if (this.yasgui.config.corsProxy && !(endpoint in Yasgui.corsEnabled)) {
-      fetch(`${endpoint}?${new URLSearchParams({ query: "ASK {?x ?y ?z}" }).toString()}`)
-        .then((response) => {
-          if (response.ok) {
-            Yasgui.corsEnabled[endpoint] = true;
-          } else {
-            throw new Error("Non-OK response");
-          }
+      const askUrl = new URL(endpoint);
+      askUrl.searchParams.append("query", "ASK {?x ?y ?z}");
+      fetch(askUrl.toString())
+        .then(() => {
+          Yasgui.corsEnabled[endpoint] = true;
         })
         .catch((e) => {
-          // If we don't get a response at all, it's likely a CORS error
+          // CORS error throws `TypeError: NetworkError when attempting to fetch resource.`
           Yasgui.corsEnabled[endpoint] = e instanceof TypeError ? false : true;
         });
     }

--- a/packages/yasqe/package.json
+++ b/packages/yasqe/package.json
@@ -28,13 +28,11 @@
     "@zazuko/yasgui-utils": "^4.3.3",
     "codemirror": "^5.51.0",
     "lodash-es": "^4.17.15",
-    "query-string": "^6.10.1",
-    "superagent": "^8.1.2"
+    "query-string": "^6.10.1"
   },
   "devDependencies": {
     "@types/codemirror": "0.0.100",
-    "@types/node": "^22.5.4",
-    "@types/superagent": "^4.1.24"
+    "@types/node": "^22.5.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/yasqe/src/autocompleters/index.ts
+++ b/packages/yasqe/src/autocompleters/index.ts
@@ -317,7 +317,7 @@ export const fetchFromLov = (
   // doRequests();
 
   const params = new URLSearchParams();
-  params.append("q", token.autocompletionString || "");
+  if (token.autocompletionString) params.append("q", token.autocompletionString);
   params.append("page_size", "50");
   params.append("type", type);
   const url = `${reqProtocol}lov.linkeddata.es/dataset/lov/api/v2/autocomplete/terms?${params.toString()}`;

--- a/packages/yasqe/src/autocompleters/index.ts
+++ b/packages/yasqe/src/autocompleters/index.ts
@@ -1,7 +1,6 @@
 import { default as Yasqe, Token, Hint, Position, Config, HintFn, HintConfig } from "../";
 import Trie from "../trie";
 import { EventEmitter } from "events";
-import * as superagent from "superagent";
 import { take } from "lodash-es";
 const CodeMirror = require("codemirror");
 require("./show-hint.scss");
@@ -316,24 +315,28 @@ export const fetchFromLov = (
   //   .append($("<span>Fetchting autocompletions &nbsp;</span>"))
   //   .append($(yutils.svg.getElement(require("../imgs.js").loader)).addClass("notificationLoader"));
   // doRequests();
-  return superagent
-    .get(reqProtocol + "lov.linkeddata.es/dataset/lov/api/v2/autocomplete/terms")
-    .query({
-      q: token.autocompletionString,
-      page_size: 50,
-      type: type,
-    })
-    .then(
-      (result) => {
-        if (result.body.results) {
-          return result.body.results.map((r: any) => r.uri[0]);
-        }
-        return [];
-      },
-      (_e) => {
-        yasqe.showNotification(notificationKey, "Failed fetching suggestions");
+
+  const params = new URLSearchParams();
+  params.append("q", token.autocompletionString || "");
+  params.append("page_size", "50");
+  params.append("type", type);
+  const url = `${reqProtocol}lov.linkeddata.es/dataset/lov/api/v2/autocomplete/terms?${params.toString()}`;
+  return fetch(url)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error("Failed fetching suggestions from Linked Open Vocabularies");
       }
-    );
+      return response.json();
+    })
+    .then((result) => {
+      if (result.results) {
+        return result.results.map((r: any) => r.uri[0]);
+      }
+      return [];
+    })
+    .catch((_e) => {
+      yasqe.showNotification(notificationKey, "Failed fetching suggestions");
+    });
 };
 
 import variableCompleter from "./variables";

--- a/packages/yasqe/src/autocompleters/prefixes.ts
+++ b/packages/yasqe/src/autocompleters/prefixes.ts
@@ -4,7 +4,6 @@ var tokenTypes: { [id: string]: "prefixed" | "var" } = {
   "string-2": "prefixed",
   atom: "var",
 };
-import * as superagent from "superagent";
 
 var conf: Autocompleter.CompleterConfig = {
   postprocessHints: function (_yasqe, hints) {
@@ -91,14 +90,21 @@ var conf: Autocompleter.CompleterConfig = {
     return true;
   },
   get: function (yasqe) {
-    return superagent.get(yasqe.config.prefixCcApi).then((resp) => {
-      var prefixArray: string[] = [];
-      for (var prefix in resp.body) {
-        var completeString = prefix + ": <" + resp.body[prefix] + ">";
-        prefixArray.push(completeString); // the array we want to store in localstorage
-      }
-      return prefixArray.sort();
-    });
+    return fetch(yasqe.config.prefixCcApi)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to fetch prefixes");
+        }
+        return response.json();
+      })
+      .then((resp) => {
+        const prefixArray: string[] = [];
+        for (const prefix in resp) {
+          const completeString = `${prefix}: <${resp[prefix]}>`;
+          prefixArray.push(completeString); // the array we want to store in local storage
+        }
+        return prefixArray.sort();
+      });
   },
   preProcessToken: function (yasqe, token) {
     var previousToken = yasqe.getPreviousNonWsToken(yasqe.getDoc().getCursor().line, token);

--- a/packages/yasqe/src/index.ts
+++ b/packages/yasqe/src/index.ts
@@ -22,8 +22,8 @@ export interface Yasqe {
   off(eventName: "query", handler: (instance: Yasqe, req: Request, abortController: AbortController) => void): void;
   on(eventName: "queryAbort", handler: (instance: Yasqe, req: Request) => void): void;
   off(eventName: "queryAbort", handler: (instance: Yasqe, req: Request) => void): void;
-  on(eventName: "queryResponse", handler: (instance: Yasqe, resp: Response, duration: number) => void): void;
-  off(eventName: "queryResponse", handler: (instance: Yasqe, resp: Response, duration: number) => void): void;
+  on(eventName: "queryResponse", handler: (instance: Yasqe, response: any, duration: number) => void): void;
+  off(eventName: "queryResponse", handler: (instance: Yasqe, response: any, duration: number) => void): void;
   showHint: (conf: HintConfig) => void;
   on(eventName: "error", handler: (instance: Yasqe) => void): void;
   off(eventName: "error", handler: (instance: Yasqe) => void): void;
@@ -131,7 +131,7 @@ export class Yasqe extends CodeMirror {
     this.abortController = abortController;
     this.updateQueryButton();
   }
-  private handleQueryResponse(_yasqe: Yasqe, _response: Response, duration: number) {
+  private handleQueryResponse(_yasqe: Yasqe, _response: any, duration: number) {
     this.lastQueryDuration = duration;
     this.req = undefined;
     this.updateQueryButton();

--- a/packages/yasqe/src/index.ts
+++ b/packages/yasqe/src/index.ts
@@ -22,8 +22,8 @@ export interface Yasqe {
   off(eventName: "query", handler: (instance: Yasqe, req: Request, abortController: AbortController) => void): void;
   on(eventName: "queryAbort", handler: (instance: Yasqe, req: Request) => void): void;
   off(eventName: "queryAbort", handler: (instance: Yasqe, req: Request) => void): void;
-  on(eventName: "queryResponse", handler: (instance: Yasqe, req: Request, duration: number) => void): void;
-  off(eventName: "queryResponse", handler: (instance: Yasqe, req: Request, duration: number) => void): void;
+  on(eventName: "queryResponse", handler: (instance: Yasqe, resp: Response, duration: number) => void): void;
+  off(eventName: "queryResponse", handler: (instance: Yasqe, resp: Response, duration: number) => void): void;
   showHint: (conf: HintConfig) => void;
   on(eventName: "error", handler: (instance: Yasqe) => void): void;
   off(eventName: "error", handler: (instance: Yasqe) => void): void;
@@ -131,7 +131,7 @@ export class Yasqe extends CodeMirror {
     this.abortController = abortController;
     this.updateQueryButton();
   }
-  private handleQueryResponse(_yasqe: Yasqe, _response: Request, duration: number) {
+  private handleQueryResponse(_yasqe: Yasqe, _response: Response, duration: number) {
     this.lastQueryDuration = duration;
     this.req = undefined;
     this.updateQueryButton();

--- a/packages/yasqe/src/sparql.ts
+++ b/packages/yasqe/src/sparql.ts
@@ -88,11 +88,11 @@ export async function executeQuery(yasqe: Yasqe, config?: YasqeAjaxConfig): Prom
     const request = new Request(populatedConfig.url, fetchOptions);
     yasqe.emit("query", request, abortController);
     const response = await fetch(request);
-    yasqe.emit("queryResponse", response, Date.now() - queryStart);
     const result = await response.json();
     if (!response.ok) {
       throw new Error(result || response.statusText);
     }
+    yasqe.emit("queryResponse", result, Date.now() - queryStart);
     yasqe.emit("queryResults", result, Date.now() - queryStart);
     return result;
   } catch (e) {

--- a/packages/yasr/package.json
+++ b/packages/yasr/package.json
@@ -48,7 +48,6 @@
     "@types/node": "^22.5.4",
     "@types/papaparse": "^5.3.2",
     "@types/sanitize-html": "^1.20.2",
-    "@types/superagent": "^4.1.4",
     "better-npm-run": "^0.1.1",
     "ts-essentials": "^7.0.1"
   },

--- a/packages/yasr/src/parsers/index.ts
+++ b/packages/yasr/src/parsers/index.ts
@@ -112,7 +112,6 @@ class Parser {
         };
       }
     }
-    console.log("got ErrorSummary", this.errorSummary);
     return this.errorSummary;
   }
   public getContentType() {

--- a/webpack/config.ts
+++ b/webpack/config.ts
@@ -169,7 +169,7 @@ export const genericConfig: webpack.Configuration = {
       },
       {
         test: /\.js$/,
-        include: [/query-string/, /strict-uri-encode/, /superagent/, /n3/, /split-on-first/],
+        include: [/query-string/, /strict-uri-encode/, /n3/, /split-on-first/],
         use: [
           {
             loader: "babel-loader",


### PR DESCRIPTION
Hi @ludovicm67 !

This PR replaces `superagent` by the standard `fetch` API, enabling us to completely remove the `superagent` dependency 🎉

And take a direction where we reduce the size of YASGUI (1MB is quite large! I think there are a few optimizations we can do to reduce this)

As far as I know fetch is really well supported now, so I don't think we really need to use `superagent` (which uses `axios` under the hood). The `fetch` API is not that complex, and usually well known from most web devs, making it easier to maintain on the long run.

I have run the tests + checked myself everything works fine (abort included)

This increase the sustainability of the software by removing, while reducing its final bundle size of about  ~6KB 5% of bundle size (from 1.07 MiB to 1.01 MiB)

Also now when a query is aborted the abort message is shown to the user instead of triggering a `console.error()` (filling up the console with hidden abort messages is not ideal imo, aborting is not an error per say)

Aborting now:

![Screenshot from 2024-10-08 10-46-42](https://github.com/user-attachments/assets/8c65082b-cb6b-45e2-8bec-8fec4d3e345c)


Aborting before:

![Screenshot from 2024-10-08 10-50-55](https://github.com/user-attachments/assets/43b46c69-3cde-4584-a9fc-33337206649b)
