### PR TITLE
Improve `div` groupment in Yasgui to enable better customization of the editor interface

### DIFF
--- a/packages/yasgui/src/Tab.ts
+++ b/packages/yasgui/src/Tab.ts
@@ -82,22 +82,28 @@ export class Tab extends EventEmitter {
     this.rootEl.setAttribute("role", "tabpanel");
     this.rootEl.setAttribute("aria-labelledby", "tab-" + this.persistentJson.id);
 
-    const wrapper = document.createElement("div");
+    // We group controlbar and Yasqe, so that users can easily .appendChild() to the .editorwrapper div
+    // to add a div that goes alongside the controlbar and editor, while YASR still goes full width
+    // Useful for adding an infos div that goes alongside the editor without needing to rebuild the whole Yasgui class
+    const editorWrapper = document.createElement("div");
+    editorWrapper.className = "editorwrapper";
+    const controlbarAndYasqeDiv = document.createElement("div");
     //controlbar
     this.controlBarEl = document.createElement("div");
     this.controlBarEl.className = "controlbar";
-    wrapper.appendChild(this.controlBarEl);
+    controlbarAndYasqeDiv.appendChild(this.controlBarEl);
 
     //yasqe
     this.yasqeWrapperEl = document.createElement("div");
-    wrapper.appendChild(this.yasqeWrapperEl);
+    controlbarAndYasqeDiv.appendChild(this.yasqeWrapperEl);
+    editorWrapper.appendChild(controlbarAndYasqeDiv);
 
     //yasr
     this.yasrWrapperEl = document.createElement("div");
-    wrapper.appendChild(this.yasrWrapperEl);
 
     this.initTabSettingsMenu();
-    this.rootEl.appendChild(wrapper);
+    this.rootEl.appendChild(editorWrapper);
+    this.rootEl.appendChild(this.yasrWrapperEl);
     this.initControlbar();
     this.initYasqe();
     this.initYasr();


### PR DESCRIPTION
Grouped the controlbar and Yasqe div elements in a div with class `.editorwrapper`. 

The main idea is that: developers deploying Yasgui should be able to easily get the div with the `.editorwrapper` class, to which they can easily `.appendChild()` a div that shows some additional info on the right of the controlbar + SPARQL editor div 

On large screens the editor usually do not need to be full screen to be comfortable. While the Yasr component still need to go full screen in most cases (usually required for readability whatever your screen size, because a lot of queries retrieves long URIs or have a lot of variables)

So it would be nice to be able to use this empty space to the right of the editor more easily

Then devs can add their own style to get the display they expect. We don't touch this so that should not change anything in current deployments

For now I moved Yasr directly as a child of the `tabPanel` div because it seemed to add 1 unecessary div, but we could also put it back in the `wrapper` div that is a child of the `tabPanel` div... Let me know what you think @ludovicm67 


Our use-case is to be able to show usable examples of SPARQL queries on the right of the editor, while still having the results in full width. Cf. demo here: https://sib-swiss.github.io/sparql-editor/ (results do not go full screen yet, that's why we are doing this PR :) )