### PR TITLE
Fix Content-Type header for `fetch` GET request 

### DIFF
--- a/.changeset/smooth-buckets-grab.md
+++ b/.changeset/smooth-buckets-grab.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/yasqe": patch
+---
+
+Fix `Content-Type` header for `fetch` GET request 

--- a/packages/yasqe/src/sparql.ts
+++ b/packages/yasqe/src/sparql.ts
@@ -57,16 +57,19 @@ export async function executeQuery(yasqe: Yasqe, config?: YasqeAjaxConfig): Prom
       return; // Nothing to query
     }
     const abortController = new AbortController();
+
     const fetchOptions: RequestInit = {
       method: populatedConfig.reqMethod,
       headers: {
         Accept: populatedConfig.accept,
         ...(populatedConfig.headers || {}),
-        "Content-Type": populatedConfig.reqMethod === "POST" ? "application/x-www-form-urlencoded" : "",
       },
       credentials: populatedConfig.withCredentials ? "include" : "same-origin",
       signal: abortController.signal,
     };
+    if (fetchOptions?.headers && populatedConfig.reqMethod === "POST") {
+      (fetchOptions.headers as Record<string, string>)["Content-Type"] = "application/x-www-form-urlencoded";
+    }
     const searchParams = new URLSearchParams();
     for (const key in populatedConfig.args) {
       const value = populatedConfig.args[key];


### PR DESCRIPTION
When building the request to send to the SPARQL endpoint we added an empty `Content-Type` header for GET request
It was fine for basic virtuoso and most endpoints, but for some endpoints that have a proxy in front to filter some of the requests it could trigger an error (e.g. uniprot endpoint)

This is fixed, no the  `Content-Type` header is either added with a value or not added at all

@ludovicm67 