### PR TITLE
Clear the endpoint select autocomplete input text field when it is focused by the user

### DIFF
--- a/packages/yasgui/src/endpointSelect.ts
+++ b/packages/yasgui/src/endpointSelect.ts
@@ -84,7 +84,8 @@ export class EndpointSelect extends EventEmitter {
     // Create field
     this.inputField = document.createElement("input");
     addClass(this.inputField, "autocomplete");
-    this.inputField.value = this.value;
+    // Clear the query string when clicking on the input field
+    this.inputField.addEventListener("focusin", () => (this.inputField.value = ""));
     autocompleteWrapper.appendChild(this.inputField);
 
     // Init autocomplete library


### PR DESCRIPTION
100% of the times a user click on the autocomplete field it is because they want to change the endpoint (otherwise why would you click on it?) 

Previously the already selected endpoint URL was automatically set as the search query, which was causing the autocomplete to filter the endpoints to only the already selected endpoint (+ all endpoints starting exactly with the same URL, which is very rare, so most of the time the user would only see the endpoint it had already selected, which is not really useful when you want to switch endpoint)

So the previous behavior required the user to manually clear the input field before they can start searching for the endpoint they want. Which was not a nice experience, as it was adding multiple steps without any reason: requires to select the whole field content with ctrl+a, then hit delete, or hit delete many many times

Now when the user click on the autocomplete field the search query starts from nothing, and all available endpoints are shown 

If the user cancel their autocomplete the previously selected endpoint comes back

@ludovicm67 