### PR TITLE
Remove a line that is clearing the hash fragment in the window URL fo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,35 @@ yarn add @zazuko/yasgui
 
 ## Local development
 
-#### Installing dependencies
+### Install dependencies
 
-Run `npm install`.
+```sh
+npm install
+```
 
-#### Running Yasgui locally
+### Run Yasgui locally
 
-To develop locally, run `npm run dev`
+To develop locally, run:
 
-#### Compiling Yasgui
+```sh
+npm run dev
+```
 
-Run `npm run build`. It'll store the transpiled js/css files in the `build` directory.
+### Compiling Yasgui
+
+It'll store the transpiled js/css files in the `build` directory. Run:
+
+```sh
+npm run build
+```
+
+### Run tests
+
+You'll first need to compile it, then run:
+
+```sh
+npm test
+```
 
 ## License
 

--- a/packages/yasgui/src/linkUtils.ts
+++ b/packages/yasgui/src/linkUtils.ts
@@ -15,7 +15,6 @@ var getUrlParams = function (_url?: string) {
     //firefox does some decoding if we're using window.location.hash (e.g. the + sign in contentType settings)
     //Don't want this. So simply get the hash string ourselves
     url.query(url.anchor());
-    if (urlFromWindow) window.location.hash = ""; //clear hash
   }
   return url;
 };


### PR DESCRIPTION
Remove a line that is clearing the hash fragment in the window URL for no reason. There are no comments in the code about why they did that. And I don't see why it is need. Anyway wherever this line is there or not, adding a # fragment is breaking the ability of Yasgui to use query params (e.g. ?query), so removing the hash does not do anything apart from introducing unwanted side effects and removing freedom from developers using Yasgui. Some developers deploying Yasgui might want to use the #, in our case it will allow to link to specific example queries so that they can be shared using their IRI 

Also improved a bit the readme docs to run tests