### PR TITLE
Enable rendering of HTML for cells with `rdf:HTML` datatype in YASR table

### DIFF
--- a/packages/yasr/src/plugins/table/index.ts
+++ b/packages/yasr/src/plugins/table/index.ts
@@ -149,6 +149,9 @@ export default class Table implements Plugin<PluginConfig> {
     if (literalBinding["xml:lang"]) {
       stringRepresentation = `"${stringRepresentation}"<sup>@${literalBinding["xml:lang"]}</sup>`;
     } else if (literalBinding.datatype) {
+      if (literalBinding.datatype === "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML") {
+        return sanitize(literalBinding.value);
+      }
       const dataType = this.getUriLinkFromBinding({ type: "uri", value: literalBinding.datatype }, prefixes);
       stringRepresentation = `"${stringRepresentation}"<sup>^^${dataType}</sup>`;
     }
@@ -328,6 +331,8 @@ export default class Table implements Plugin<PluginConfig> {
     const switchComponent = document.createElement("label");
     const textComponent = document.createElement("span");
     textComponent.innerText = "Simple view";
+    toggleWrapper.title =
+      "Simple view hides the row numbers and presents the results as they are, without additional styling. Disabling it will render cells with datatype rdf:HTML.";
     addClass(textComponent, "label");
     switchComponent.appendChild(textComponent);
     addClass(switchComponent, "switch");
@@ -344,6 +349,7 @@ export default class Table implements Plugin<PluginConfig> {
     const ellipseSwitchComponent = document.createElement("label");
     const ellipseTextComponent = document.createElement("span");
     ellipseTextComponent.innerText = "Ellipse";
+    ellipseToggleWrapper.title = "Shorten long text content in the table cells";
     addClass(ellipseTextComponent, "label");
     ellipseSwitchComponent.appendChild(ellipseTextComponent);
     addClass(ellipseSwitchComponent, "switch");


### PR DESCRIPTION
Add rendering of HTML in the default YASR table for cell that have the datatype `rdf:HTML`. We have some people at SIB that wants it particularly to display images. I think it makes sense to be in the default implementation, if the datatype is HTML then the users would better see it as rendered HTML

I was considering adding a checkbox `Render HTML` to enable it/disable it. But simple view already does it

I have also added `.title` to give more explanationation about each checkbox effect when hovering them with the mouse

You can test HTML rendering with this query:

```sparql
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>

SELECT ?img ?span WHERE {
  BIND("<img src='https://raw.githubusercontent.com/sib-swiss/sparql-llm/refs/heads/main/chat-with-context/demo/sib-logo.png' />"^^rdf:HTML AS ?img)
  BIND("<span style='color: red;'>toast</span>"^^rdf:HTML AS ?span)
}
```

@ludovicm67 