### PR TITLE
Fix response parser to handle construct and describe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15889,7 +15889,7 @@
     },
     "packages/utils": {
       "name": "@zazuko/yasgui-utils",
-      "version": "4.4.3",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "dompurify": "^3.2.4",
@@ -15920,13 +15920,13 @@
     },
     "packages/yasgui": {
       "name": "@zazuko/yasgui",
-      "version": "4.4.3",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "@tarekraafat/autocomplete.js": "^7.2.0",
-        "@zazuko/yasgui-utils": "^4.4.3",
-        "@zazuko/yasqe": "^4.4.3",
-        "@zazuko/yasr": "^4.4.3",
+        "@zazuko/yasgui-utils": "^4.5.0",
+        "@zazuko/yasqe": "^4.5.0",
+        "@zazuko/yasr": "^4.5.0",
         "autosuggest-highlight": "^3.1.1",
         "blueimp-md5": "^2.12.0",
         "choices.js": "^9.0.1",
@@ -15965,10 +15965,10 @@
     },
     "packages/yasqe": {
       "name": "@zazuko/yasqe",
-      "version": "4.4.3",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
-        "@zazuko/yasgui-utils": "^4.4.3",
+        "@zazuko/yasgui-utils": "^4.5.0",
         "codemirror": "^5.51.0",
         "lodash-es": "^4.17.15",
         "query-string": "^6.10.1"
@@ -15994,13 +15994,13 @@
     },
     "packages/yasr": {
       "name": "@zazuko/yasr",
-      "version": "4.4.3",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
         "@json2csv/plainjs": "^7.0.4",
-        "@zazuko/yasgui-utils": "^4.4.3",
-        "@zazuko/yasqe": "^4.4.3",
+        "@zazuko/yasgui-utils": "^4.5.0",
+        "@zazuko/yasqe": "^4.5.0",
         "codemirror": "^5.51.0",
         "colors": "^1.4.0",
         "column-resizer": "^1.4.0",

--- a/packages/yasqe/src/sparql.ts
+++ b/packages/yasqe/src/sparql.ts
@@ -94,7 +94,7 @@ export async function executeQuery(yasqe: Yasqe, config?: YasqeAjaxConfig): Prom
     if (!response.ok) {
       throw new Error((await response.text()) || response.statusText);
     }
-    // Await the body so we can handle it without the need for async everywhere in the Parser
+    // Await the response content
     const queryResponse = {
       content: await response.text(),
       ...response,

--- a/packages/yasqe/src/sparql.ts
+++ b/packages/yasqe/src/sparql.ts
@@ -96,14 +96,11 @@ export async function executeQuery(yasqe: Yasqe, config?: YasqeAjaxConfig): Prom
     }
     // Await the body so we can handle it without the need for async everywhere in the Parser
     const queryResponse = {
-      headers: response.headers,
-      status: response.status,
-      statusText: response.statusText,
-      url: response.url,
-      text: await response.text(),
+      content: await response.text(),
+      ...response,
     };
     yasqe.emit("queryResponse", queryResponse, Date.now() - queryStart);
-    yasqe.emit("queryResults", queryResponse.text, Date.now() - queryStart);
+    yasqe.emit("queryResults", queryResponse.content, Date.now() - queryStart);
     return queryResponse;
   } catch (e) {
     if (e instanceof Error && e.message === "Aborted") {

--- a/packages/yasqe/src/sparql.ts
+++ b/packages/yasqe/src/sparql.ts
@@ -91,18 +91,20 @@ export async function executeQuery(yasqe: Yasqe, config?: YasqeAjaxConfig): Prom
     const request = new Request(populatedConfig.url, fetchOptions);
     yasqe.emit("query", request, abortController);
     const response = await fetch(request);
-    let result = await response.text();
-    try {
-      result = JSON.parse(result);
-    } catch (e) {
-      // ignore
-    }
     if (!response.ok) {
-      throw new Error(result || response.statusText);
+      throw new Error((await response.text()) || response.statusText);
     }
-    yasqe.emit("queryResponse", result, Date.now() - queryStart);
-    yasqe.emit("queryResults", result, Date.now() - queryStart);
-    return result;
+    // Await the body so we can handle it without the need for async everywhere in the Parser
+    const queryResponse = {
+      headers: response.headers,
+      status: response.status,
+      statusText: response.statusText,
+      url: response.url,
+      text: await response.text(),
+    };
+    yasqe.emit("queryResponse", queryResponse, Date.now() - queryStart);
+    yasqe.emit("queryResults", queryResponse.text, Date.now() - queryStart);
+    return queryResponse;
   } catch (e) {
     if (e instanceof Error && e.message === "Aborted") {
       // The query was aborted. We should not do or draw anything

--- a/packages/yasr/src/parsers/index.ts
+++ b/packages/yasr/src/parsers/index.ts
@@ -56,12 +56,8 @@ const applyMustacheToLiterals: Parser.PostProcessBinding = (binding: Parser.Bind
   return binding;
 };
 
-type QueryResponse = {
-  status: number;
-  statusText: string;
-  headers: Headers;
-  url: string;
-  text: string;
+type QueryResponse = Response & {
+  content: string;
 };
 
 /**
@@ -80,7 +76,7 @@ class Parser {
     if (executionTime) this.executionTime = executionTime; // Parameter has priority
     if (responseOrObject instanceof Error) {
       this.error = responseOrObject;
-    } else if ((<any>responseOrObject).text) {
+    } else if ((<any>responseOrObject).content) {
       this.setResponse(<QueryResponse>responseOrObject);
     } else {
       this.setSummary(<Parser.ResponseSummary>responseOrObject);
@@ -143,7 +139,7 @@ class Parser {
   }
   private getData(): any {
     if (this.res) {
-      if (this.res.text) return this.res.text;
+      if (this.res.content) return this.res.content;
     }
     if (this.summary) return this.summary.data;
   }


### PR DESCRIPTION
Right now  the `Parser` class does not handle well the response retrieved by fetch, especially for construct/describe.

It is because we just provide the response content directly instead of the whole response (which has metadata such as headers + the actual response content)

2 solutions possible:

- [ ] We pass the unmodified fetch Response to the `Parser` class, which will need to `await` the content.

  - In `sparql.ts` we are expected to provide the response content, so we would need to clone the response in order to get the content twice, since once we did `await response.text()` we cannot do it again.

    ```ts
    yasqe.emit("queryResults", await (response.clone()).text(), Date.now() - queryStart);
    ```

  - The main issue with this approach is that currently the `Parser` class is not async at all, so that means we will need to make `private getData()` async, which will require to make all other functions depending on getData also async... Which will be quite the rabbit hole to go down.

  - Also `response.text()` can only be awaited once, so we will need to change a bit more the Parser inner working to make sure it is only awaited once (right now the `Parser` is a bit messy because the previous devs wanted it to be able to handle many types of different response/errors (because they used super-agent, but people using the `Parser` with YASR might not have been using super-agent, so they tried to make it work for many other solutions).

  - The advantage is that people using YASR without YASQE will be able to just pass a standard fetch Response to the Parser and everything will be handled for them

- [x] Other solution would be to await only once in `sparql.ts`, then we send a response with the already awaited content to Parser.

  - Advantage is that `Parser` don't need to become `async`.

  - Disadvantage is that people using YASR and Parser without YASQE will need to await the `.text()` themselves and pass a `Response` object with an additional `.content` field, typically just doing this:

    ```ts
    const queryResponse = {
      content: await response.text(),
      ...response,
    };
    ```

    Or we could make it so the Parser construtor takes 2 separate arguments: actual response content + response metadata  

For now I chose the latter. Because it works well with the current state of the code and does not require major changes. 

@ludovicm67 