### PR TITLE
Fix the `json.ts` parser for ASK queries when the `queryResponse` is a string

### DIFF
--- a/packages/yasr/src/parsers/json.ts
+++ b/packages/yasr/src/parsers/json.ts
@@ -2,7 +2,7 @@ import Parser from "./";
 export default function (queryResponse: any, postProcessBinding: Parser.PostProcessBinding): Parser.SparqlResults {
   if (typeof queryResponse == "string") {
     const json = JSON.parse(queryResponse);
-    if (postProcessBinding) {
+    if (postProcessBinding && json.results) {
       for (const binding in json.results.bindings) {
         json.results.bindings[binding] = postProcessBinding(json.results.bindings[binding]);
       }


### PR DESCRIPTION
Hi @ludovicm67, I noticed getting this error when trying to do a ASK query (e.g. `ASK WHERE {?s ?p ?o}` on DBpedia):

```
can't access property "bindings", json.results is undefined
```

The error comes from the `parsers/json.ts` first `for (const binding in json.results.bindings)`:

```ts
  if (typeof queryResponse == "string") {
    const json = JSON.parse(queryResponse);
    if (postProcessBinding) {
      for (const binding in json.results.bindings) {
        json.results.bindings[binding] = postProcessBinding(json.results.bindings[binding]);
      }
    }
    return json;
  }
  if (typeof queryResponse == "object" && queryResponse.constructor === {}.constructor) {
    // an ASK-query only returns a "boolean" field so we should check if are undefined here
    if (postProcessBinding && queryResponse.results) {
      for (const binding in queryResponse.results.bindings) {
        queryResponse.results.bindings[binding] = postProcessBinding(queryResponse.results.bindings[binding]);
      }
    }
    return queryResponse;
  }
```

In the first `if` when queryResponse is a string, there was no check for `&& queryResponse.results`. But this check was properly in place when queryResponse was an object. So the parser would break for ASK queries (no results) if the response was a string, and not yet parsed

Note the old comment explicitly acknowledging this required check when the queryResponse is an object

I guess in the past the queryReponse arrived directly as an object most of the time, so this missing check was never noticed