### PR TITLE
add a new checkbox to the yasgui settings, allow using password protected endpoint

### DIFF
--- a/packages/yasgui/src/TabPanel.ts
+++ b/packages/yasgui/src/TabPanel.ts
@@ -77,6 +77,11 @@ export default class TabPanel {
     // Draw Accept headers
     this.setAcceptHeader_select(<string>reqConfig.acceptHeaderSelect);
     this.setAcceptHeader_graph(<string>reqConfig.acceptHeaderGraph);
+
+    if (typeof reqConfig.withCredentials !== "function") {
+      this.setUseLogin(reqConfig.withCredentials);
+    }
+
     if (typeof reqConfig.args !== "function") {
       this.setArguments([...(reqConfig.args || [])]);
     }
@@ -191,6 +196,32 @@ export default class TabPanel {
     );
 
     this.menuElement.appendChild(acceptWrapper);
+  }
+
+  private setUseLogin!: (useLogin: boolean) => void;
+  private drawUseLoginInput() {
+    const useLoginWrapper = document.createElement("div");
+    addClass(useLoginWrapper, "requestConfigWrapper");
+    createLabel("Use browser login", useLoginWrapper);
+
+    // Create Button
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    if (this.tab.getRequestConfig().withCredentials) {
+      checkbox.checked = true;
+    }
+
+    this.setUseLogin = (useLogin) => {
+      checkbox.checked = useLogin;
+    };
+    checkbox.onclick = (ev) => {
+      this.tab.setRequestConfig({ withCredentials: checkbox.checked });
+      ev.stopPropagation();
+    };
+
+    // Add elements to container
+    useLoginWrapper.appendChild(checkbox);
+    this.menuElement.appendChild(useLoginWrapper);
   }
 
   private setArguments!: (args: TextInputPair[]) => void;
@@ -335,6 +366,9 @@ export default class TabPanel {
   private drawBody() {
     // Draw request Method
     this.drawRequestMethodSelector();
+
+    // Draw use login
+    this.drawUseLoginInput();
 
     // Draw Accept headers
     this.drawAcceptSelector();

--- a/packages/yasgui/src/index.ts
+++ b/packages/yasgui/src/index.ts
@@ -313,6 +313,7 @@ export class Yasgui extends EventEmitter {
       const currentTab = this.getTab();
       if (currentTab) {
         tabConfig.requestConfig.endpoint = currentTab.getEndpoint();
+        tabConfig.requestConfig.withCredentials = currentTab.getRequestConfig().withCredentials;
       }
     }
     if (opts.avoidDuplicateTabs) {

--- a/packages/yasgui/src/linkUtils.ts
+++ b/packages/yasgui/src/linkUtils.ts
@@ -73,6 +73,7 @@ export function createShareLink(forUrl: string, tab: Tab) {
 export type ShareConfigObject = {
   query: string;
   endpoint: string;
+  useLogin: boolean;
   requestMethod: PlainRequestConfig["method"];
   tabTitle: string;
   headers: PlainRequestConfig["headers"];
@@ -92,6 +93,7 @@ export function createShareConfig(tab: Tab): ShareConfigObject {
   return {
     query: tab.getQuery(),
     endpoint: tab.getEndpoint(),
+    useLogin: getAsValue(requestConfig.withCredentials, yasgui),
     requestMethod: getAsValue(requestConfig.method, yasgui),
     tabTitle: tab.getName(),
     // headers: isFunction(requestConfig.headers) ? requestConfig.headers(tab.yasgui) : requestConfig.headers,
@@ -134,6 +136,8 @@ export function getConfigFromUrl(defaults: PersistedJson, _url?: string): Persis
       options.requestConfig.acceptHeaderSelect = value;
     } else if (key == "endpoint") {
       options.requestConfig.endpoint = value;
+    } else if (key == "useLogin") {
+      options.requestConfig.withCredentials = value === "true";
     } else if (key == "requestMethod") {
       options.requestConfig.method = <any>value;
     } else if (key == "tabTitle") {


### PR DESCRIPTION
Some endpoints are protected with basic auth

see

- https://github.com/Triply-Dev/YASGUI.YASQE-deprecated/issues/94
- https://github.com/TriplyDB/Yasgui/issues/45

I have tested the code with our public and password protected [fuseki](https://jena.apache.org/documentation/fuseki2/)

you can enable the "login" request in the cogwheel settings, thus it does not break any normal non-protected endpoints. When enabled, the withCredentials flag is turned on and iff the endpoint does require authentication, the user is prompted by their browser to fill in the HTTP basic auth credentials. The browser caches this login for the rest of the session

if you on the other hand enable the checkbox on a public endpoint, then you get an error message (in Firefox, NetworkError when attempting to fetch resource.)

This is a copy of https://github.com/TriplyDB/Yasgui/pull/211

<img width="815" height="241" alt="Screenshot From 2026-01-22 16-07-49" src="https://github.com/user-attachments/assets/c3492897-6e08-46a8-9509-de4024611d11" />
