### PR TITLE
update lodash-es to version 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3922,6 +3923,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -4364,6 +4366,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4434,6 +4437,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5167,6 +5171,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6475,7 +6480,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
       "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -6923,6 +6929,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9104,9 +9111,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -10420,6 +10427,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11780,6 +11788,7 @@
       "integrity": "sha512-N+7WK20/wOr7CzA2snJcUSSNTCzeCGUTFY3OgeQP3mZ1aj9NMQ0mSTXwlrnd89j33zzQJGqIN52GIOmYrfq46A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -11860,6 +11869,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13246,6 +13256,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13362,7 +13373,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -13437,6 +13449,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13651,6 +13664,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -14509,7 +14523,7 @@
     },
     "packages/utils": {
       "name": "@zazuko/yasgui-utils",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "MIT",
       "dependencies": {
         "dompurify": "^3.2.4",
@@ -14531,20 +14545,20 @@
     },
     "packages/yasgui": {
       "name": "@zazuko/yasgui",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "MIT",
       "dependencies": {
         "@tarekraafat/autocomplete.js": "^7.2.0",
-        "@zazuko/yasgui-utils": "^4.6.0",
-        "@zazuko/yasqe": "^4.6.0",
-        "@zazuko/yasr": "^4.6.0",
+        "@zazuko/yasgui-utils": "^4.6.1",
+        "@zazuko/yasqe": "^4.6.1",
+        "@zazuko/yasr": "^4.6.1",
         "autosuggest-highlight": "^3.1.1",
         "blueimp-md5": "^2.12.0",
         "choices.js": "^9.0.1",
         "dompurify": "^3.2.4",
         "es6-object-assign": "^1.1.0",
         "jsuri": "^1.3.1",
-        "lodash-es": "^4.17.15",
+        "lodash-es": "^4.18.1",
         "sortablejs": "^1.10.2"
       },
       "devDependencies": {
@@ -14567,12 +14581,12 @@
     },
     "packages/yasqe": {
       "name": "@zazuko/yasqe",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "MIT",
       "dependencies": {
-        "@zazuko/yasgui-utils": "^4.6.0",
+        "@zazuko/yasgui-utils": "^4.6.1",
         "codemirror": "^5.51.0",
-        "lodash-es": "^4.17.15",
+        "lodash-es": "^4.18.1",
         "query-string": "^6.10.1"
       },
       "devDependencies": {
@@ -14596,13 +14610,13 @@
     },
     "packages/yasr": {
       "name": "@zazuko/yasr",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
         "@json2csv/plainjs": "^7.0.4",
-        "@zazuko/yasgui-utils": "^4.6.0",
-        "@zazuko/yasqe": "^4.6.0",
+        "@zazuko/yasgui-utils": "^4.6.1",
+        "@zazuko/yasqe": "^4.6.1",
         "codemirror": "^5.51.0",
         "colors": "^1.4.0",
         "column-resizer": "^1.4.0",
@@ -14610,7 +14624,7 @@
         "datatables.net-dt": "^2.0.5",
         "dompurify": "^3.2.4",
         "jquery": "^3.7.1",
-        "lodash-es": "^4.17.15",
+        "lodash-es": "^4.18.1",
         "n3": "^1.3.5",
         "papaparse": "^5.3.1"
       },

--- a/packages/yasgui/package.json
+++ b/packages/yasgui/package.json
@@ -31,7 +31,7 @@
     "dompurify": "^3.2.4",
     "es6-object-assign": "^1.1.0",
     "jsuri": "^1.3.1",
-    "lodash-es": "^4.17.15",
+    "lodash-es": "^4.18.1",
     "sortablejs": "^1.10.2"
   },
   "devDependencies": {

--- a/packages/yasqe/package.json
+++ b/packages/yasqe/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@zazuko/yasgui-utils": "^4.6.1",
     "codemirror": "^5.51.0",
-    "lodash-es": "^4.17.15",
+    "lodash-es": "^4.18.1",
     "query-string": "^6.10.1"
   },
   "devDependencies": {

--- a/packages/yasr/package.json
+++ b/packages/yasr/package.json
@@ -35,7 +35,7 @@
     "datatables.net-dt": "^2.0.5",
     "dompurify": "^3.2.4",
     "jquery": "^3.7.1",
-    "lodash-es": "^4.17.15",
+    "lodash-es": "^4.18.1",
     "n3": "^1.3.5",
     "papaparse": "^5.3.1"
   },


### PR DESCRIPTION
This PR updates project dependencies to address identified security risks and ensure compliance with build quality standards.

Updated all outdated lodah-es dependencies to their latest stable versions 4.18.1
Resolved known vulnerabilities in transitive dependencies
